### PR TITLE
Move head meta and link tags to header-footer.ts

### DIFF
--- a/pages/public/index.html
+++ b/pages/public/index.html
@@ -2,16 +2,8 @@
 <html lang="nb">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hjemmeside | HopFiks.no</title>
     <script src="./script/header-footer.js" defer></script>
-    <link rel="stylesheet" href="./style/base.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-        rel="stylesheet">
-    <link rel="icon" href="./img/rabbit.svg" type="image/svg+xml">
 </head>
 
 <body>

--- a/src/frontend/header-footer.ts
+++ b/src/frontend/header-footer.ts
@@ -1,6 +1,18 @@
 (() => {
     const body = document.body;
+    const head = document.head;
     if (!body) return;
+    if (!head) return;
+    head.innerHTML = `
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./style/base.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+        rel="stylesheet">
+    <link rel="icon" href="./img/rabbit.svg" type="image/svg+xml">
+    `;
     const header = document.createElement("header");
     const footer = document.createElement("footer");
     header.innerHTML = "<h1> YO dude</h1>";


### PR DESCRIPTION
Removed meta and link tags from index.html and injected them dynamically via header-footer.ts. This centralizes head element management in the frontend script.